### PR TITLE
remove deprecated extractCss and fix load link with hash

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -26,7 +26,6 @@
               "src/favicon.ico",
               "src/assets"
             ],
-            "extractCss": true,
             "styles": [
               "node_modules/@clr/icons/clr-icons.min.css",
               { "input": "src/styles.dark.scss", "bundleName": "styles-theme-dark", "inject": false },

--- a/src/app/services/theme/theme.service.ts
+++ b/src/app/services/theme/theme.service.ts
@@ -5,6 +5,7 @@ import { DOCUMENT } from '@angular/common';
 export interface ThemeMetadata {
   name: 'light' | 'dark';
   displayName: string;
+  hashName?: string;
 }
 
 
@@ -15,7 +16,7 @@ export class ThemeService {
 
   private themes: ThemeMetadata[] = [{
     displayName: 'Light',
-    name: 'light',
+    name: 'light'
   }, {
     displayName: 'Dark',
     name: 'dark',
@@ -43,10 +44,23 @@ export class ThemeService {
     for (const link of links) {
       if (link.href.includes(this.styleSelector)) {
         link.id = this.styleID;
-        const themeName = link.href.split(this.styleSelector)[1]?.split('.css')[0];
-        const initialTheme = this.themes.find(t => t.name === themeName);
-        if(initialTheme){
-          this.activeTheme.next(initialTheme);
+
+        /** https://github.com/angular/angular-cli/blob/0afdff028cba0e5ab44323f4e37d1a0dc9abb14c/packages/angular_devkit/build_angular/src/builders/browser/tests/options/styles_spec.ts
+        * angular.angular.json
+        *  - styles[ {... inject: true }] -> adds link to html but with a hash
+        *  - production.optimization.inlineCritical = false -> removes the injected style element, only places link from inject
+        *
+        * light.<hash>.css
+        * -> save the hashName and use it later
+        */
+        const hashName = link.href.split(this.styleSelector)[1]?.split('.css')[0];
+        if (hashName) {
+          const themeName = hashName.split('.')[0];
+          const initialTheme = this.themes.find(t => t.name === themeName);
+          initialTheme.hashName = hashName;
+          if (initialTheme) {
+            this.activeTheme.next(initialTheme);
+          }
         }
       }
     }
@@ -70,15 +84,23 @@ export class ThemeService {
     const hasStyle = this.document.getElementById(this.styleID) as HTMLLinkElement;
     if (hasStyle) {
       if (hasStyle.href !== `${this.styleSelector}${theme.name}.css`) {
-        hasStyle.href = `${this.styleSelector}${theme.name}.css`;
+        this.setLinkHref(theme, hasStyle);
       }
     } else {
       const head = this.document.getElementsByTagName('head')[0];
       const link = this.document.createElement('link');
       link.rel = 'stylesheet';
       link.id = this.styleID;
-      link.href = `${this.styleSelector}${theme.name}.css`;
+      this.setLinkHref(theme, link);
       head.appendChild(link);
+    }
+  }
+
+  private setLinkHref(theme: ThemeMetadata, link: HTMLLinkElement) {
+    if (theme.hashName) {
+      link.href = `${this.styleSelector}${theme.hashName}.css`;
+    } else {
+      link.href = `${this.styleSelector}${theme.name}.css`;
     }
   }
 }


### PR DESCRIPTION
Get the hash name from the style and use it later so link is not broken.

@MichaelLangbein this should fix the problem.